### PR TITLE
Fix: Resolve ModuleNotFoundError for backend app

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -9,7 +9,7 @@ import json
 from datetime import datetime, timedelta
 
 from . import models, schemas
-from backend.ml.predictor import MLPredictor
+from ml.predictor import MLPredictor
 
 class TelemetryCRUD:
     """CRUD operations for telemetry data."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,16 +14,16 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
-from backend.app.database import SessionLocal, engine, get_db
-from backend.app.models import Base
-from backend.app.schemas import (
+from .database import SessionLocal, engine, get_db
+from .models import Base
+from .schemas import (
     TelemetryCreate, Telemetry, TelemetryUpdate, PredictionRequest, PredictionResponse,
     AnomalyRequest, AnomalyResponse, ExplanationResponse, ModelMetricsResponse,
     AlertRequest, WebSocketMessage, HealthResponse
 )
-from backend.app.crud import TelemetryCRUD, ModelMetricsCRUD, AlertLogCRUD
-from backend.ml.predictor import MLPredictor
-from backend.app.alerts import AlertManager
+from .crud import TelemetryCRUD, ModelMetricsCRUD, AlertLogCRUD
+from ml.predictor import MLPredictor
+from .alerts import AlertManager
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Corrected import statements in `backend/app/main.py` and `backend/app/crud.py` to use relative imports for intra-package modules and direct imports for modules in sibling directories that are part of PYTHONPATH.

This change ensures that Python can correctly locate modules when the application is run inside the Docker container, where the working directory and PYTHONPATH are set to `/app` and the `backend` directory's contents are copied into `/app`.